### PR TITLE
#7 change regex pattern to allow one dot in resource type

### DIFF
--- a/resources/api/essentials-api.yaml
+++ b/resources/api/essentials-api.yaml
@@ -293,7 +293,7 @@ parameters:
     type: string
     description: ID of the resource type
     required: true
-    pattern: "^[a-z][a-z0-9-_]*[a-z0-9]$"
+    pattern: "^[a-z][a-z0-9-_]*(?:\.[a-z0-9-_]*)?[a-z0-9]$"
 
   ScopeID:
     name: scope_id

--- a/resources/api/essentials-api.yaml
+++ b/resources/api/essentials-api.yaml
@@ -293,7 +293,7 @@ parameters:
     type: string
     description: ID of the resource type
     required: true
-    pattern: "^[a-z][a-z0-9-_]*(?:\.[a-z0-9-_]*)?[a-z0-9]$"
+    pattern: "^[a-z][a-z0-9-_]*(?:\\.[a-z0-9-_]*)?[a-z0-9]$"
 
   ScopeID:
     name: scope_id


### PR DESCRIPTION
Fixes #7 

Tried locally, seems to work fine:

```
GET localhost:8080/resource-types

[
  {
    id: "kio-foo_bar.write",
    name: "Kio Write"
  },
  {
    id: "kio_foo.write",
    name: "Kio Write"
  },
  {
    id: "kio-foo.write",
    name: "Kio Write"
  },
  {
    id: "kio.write",
    name: "Kio Write"
  }
]
```
