### PR TITLE
Alter permission model

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,8 @@
 
             :dependencies [[org.clojure/clojure "1.8.0"]
                            [org.zalando.stups/friboo "1.7.0"]
+                           [org.zalando.stups/tokens "0.9.9"]
+                           [clj-http "2.1.0"]
                            [yesql "0.5.2"]]
 
             :main ^:skip-aot org.zalando.stups.essentials.core

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,6 @@
 
             :dependencies [[org.clojure/clojure "1.8.0"]
                            [org.zalando.stups/friboo "1.7.0"]
-                           [org.zalando.stups/tokens "0.9.9"]
                            [clj-http "2.1.0"]
                            [yesql "0.5.2"]]
 

--- a/src/org/zalando/stups/essentials/api.clj
+++ b/src/org/zalando/stups/essentials/api.clj
@@ -32,7 +32,7 @@
   {:http-port 8080})
 
 (defn get-access-token [request]
-  (get-in request [:tokeninfo "access_token"] nil))
+  (get-in request [:tokeninfo "access_token"]))
 
 (defn require-special-uid
   "Checks wether a given user is configured to be allowed to access this endpoint. Workaround for now."

--- a/src/org/zalando/stups/essentials/api.clj
+++ b/src/org/zalando/stups/essentials/api.clj
@@ -84,7 +84,9 @@
 (defn read-resource-types
   "Provides a list of all resource types"
   [_ request db]
-  (u/require-realms #{"services" "employees"} request)
+  (if (:tokeninfo request)
+    (u/require-realms #{"services" "employees"} request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Read all resource types...")
   (->> (sql/cmd-read-resource-types {} {:connection db})
        (map strip-prefix)
@@ -94,7 +96,9 @@
 (defn read-resource-type
   "Reads detailed information about ine resource type from database"
   [{:keys [resource_type_id]} request db]
-  (u/require-realms #{"services" "employees"} request)
+  (if (:tokeninfo request)
+    (u/require-realms #{"services" "employees"} request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Read resource type '%s'..." resource_type_id)
   (if-let [resource-type (load-resource-type resource_type_id db)]
     (content-type-json (response resource-type))
@@ -130,8 +134,10 @@
 (defn create-or-update-resource-type
   "Creates or updates a resource type"
   [{:keys [resource_type_id resource_type]} request db]
+  (if (:tokeninfo request)
+    (require-write-access resource_type_id request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Saving resource type '%s'..." resource_type_id)
-  (require-write-access resource_type_id request)
   (validate-resource-owners (:resource_owners resource_type) resource_type_id db request)
   (sql/cmd-create-or-update-resource-type!
     {:resource_type_id resource_type_id
@@ -145,7 +151,9 @@
 (defn delete-resource-type
   "Deletes a resource type from the database"
   [{:keys [resource_type_id]} request db]
-  (require-write-access resource_type_id request)
+  (if (:tokeninfo request)
+    (require-write-access resource_type_id request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Deleting resource type '%s' ..." resource_type_id)
   (let [deleted (pos? (sql/cmd-delete-resource-type! {:resource_type_id resource_type_id} {:connection db}))]
     (if deleted
@@ -156,7 +164,9 @@
 (defn read-scopes
   "Reads the scopes of one resource type from database"
   [{:keys [resource_type_id]} request db]
-  (u/require-realms #{"services" "employees"} request)
+  (if (:tokeninfo request)
+    (u/require-realms #{"services" "employees"} request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Read scopes of resource type '%s' ..." resource_type_id)
   (->> (sql/cmd-read-scopes {:resource_type_id resource_type_id} {:connection db})
        (map strip-prefix)
@@ -166,7 +176,9 @@
 (defn read-scope
   "Read one scope from database"
   [{:keys [resource_type_id scope_id]} request db]
-  (u/require-realms #{"services" "employees"} request)
+  (if (:tokeninfo request)
+    (u/require-realms #{"services" "employees"} request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Read scope '%s' of resource type '%s' ..." scope_id resource_type_id)
   (->> (sql/cmd-read-scope {:resource_type_id resource_type_id
                             :scope_id         scope_id} {:connection db})
@@ -177,7 +189,9 @@
 (defn create-or-update-scope
   "Creates or updates a scope"
   [{:keys [resource_type_id scope_id scope]} request db]
-  (require-write-access resource_type_id request)
+  (if (:tokeninfo request)
+    (require-write-access resource_type_id request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Saving scope '%s' of resource type '%s'..." scope_id resource_type_id)
   (if-let [resource-type (load-resource-type resource_type_id db)]
     (do (when (and (:is_resource_owner_scope scope)
@@ -202,7 +216,9 @@
 (defn delete-scope
   "Deletes a scope"
   [{:keys [resource_type_id scope_id]} request db]
-  (require-write-access resource_type_id request)
+  (if (:tokeninfo request)
+    (require-write-access resource_type_id request)
+    (log/warn "Could not validate authorization due to missing tokeninfo. Set HTTP_TOKENINFO_URL to enable full validation"))
   (log/debug "Deleting scope '%s' of resource type '%s'..." scope_id resource_type_id)
   (if (load-resource-type resource_type_id db)
     (do (sql/cmd-delete-scope! {:resource_type_id resource_type_id :scope_id scope_id}

--- a/src/org/zalando/stups/essentials/api.clj
+++ b/src/org/zalando/stups/essentials/api.clj
@@ -61,7 +61,7 @@
 (defn read-resource-types
   "Provides a list of all resource types"
   [_ request db]
-  (u/require-internal-user request)
+  (u/require-realms #{"services" "employees"} request)
   (log/debug "Read all resource types...")
   (->> (sql/cmd-read-resource-types {} {:connection db})
        (map strip-prefix)
@@ -71,7 +71,7 @@
 (defn read-resource-type
   "Reads detailed information about ine resource type from database"
   [{:keys [resource_type_id]} request db]
-  (u/require-internal-user request)
+  (u/require-realms #{"services" "employees"} request)
   (log/debug "Read resource type '%s'..." resource_type_id)
   (if-let [resource-type (load-resource-type resource_type_id db)]
     (content-type-json (response resource-type))
@@ -137,7 +137,7 @@
 (defn read-scopes
   "Reads the scopes of one resource type from database"
   [{:keys [resource_type_id]} request db]
-  (u/require-internal-user request)
+  (u/require-realms #{"services" "employees"} request)
   (log/debug "Read scopes of resource type '%s' ..." resource_type_id)
   (->> (sql/cmd-read-scopes {:resource_type_id resource_type_id} {:connection db})
        (map strip-prefix)
@@ -147,7 +147,7 @@
 (defn read-scope
   "Read one scope from database"
   [{:keys [resource_type_id scope_id]} request db]
-  (u/require-internal-user request)
+  (u/require-realms #{"services" "employees"} request)
   (log/debug "Read scope '%s' of resource type '%s' ..." scope_id resource_type_id)
   (->> (sql/cmd-read-scope {:resource_type_id resource_type_id
                             :scope_id         scope_id} {:connection db})

--- a/src/org/zalando/stups/essentials/core.clj
+++ b/src/org/zalando/stups/essentials/core.clj
@@ -16,7 +16,6 @@
   (:require [org.zalando.stups.friboo.config :as config]
             [org.zalando.stups.friboo.system :as system]
             [org.zalando.stups.friboo.log :as log]
-            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [org.zalando.stups.essentials.sql :as sql]
             [org.zalando.stups.essentials.api :as api])
   (:gen-class))
@@ -30,9 +29,7 @@
                          api/default-http-configuration
                          default-configuration])
         system (system/http-system-map configuration
-                                       api/map->API [:db :tokens]
-                                       :tokens (oauth2/map->OAUth2TokenRefresher {:configuration (:oauth2 configuration)
-                                                                                  :tokens {:kio ["uid"]}})
+                                       api/map->API [:db]
                                        :db (sql/map->DB {:configuration (:db configuration)}))]
     (system/run configuration system)))
 

--- a/src/org/zalando/stups/essentials/core.clj
+++ b/src/org/zalando/stups/essentials/core.clj
@@ -16,6 +16,7 @@
   (:require [org.zalando.stups.friboo.config :as config]
             [org.zalando.stups.friboo.system :as system]
             [org.zalando.stups.friboo.log :as log]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth2]
             [org.zalando.stups.essentials.sql :as sql]
             [org.zalando.stups.essentials.api :as api])
   (:gen-class))
@@ -24,12 +25,14 @@
   "Initializes and starts the whole system."
   [default-configuration]
   (let [configuration (config/load-configuration
-                        (system/default-http-namespaces-and :db :essentials)
+                        (system/default-http-namespaces-and :db :essentials :oauth2)
                         [sql/default-db-configuration
                          api/default-http-configuration
                          default-configuration])
         system (system/http-system-map configuration
-                                       api/map->API [:db]
+                                       api/map->API [:db :tokens]
+                                       :tokens (oauth2/map->OAUth2TokenRefresher {:configuration (:oauth2 configuration)
+                                                                                  :tokens {:kio ["uid"]}})
                                        :db (sql/map->DB {:configuration (:db configuration)}))]
     (system/run configuration system)))
 

--- a/src/org/zalando/stups/essentials/core.clj
+++ b/src/org/zalando/stups/essentials/core.clj
@@ -24,7 +24,7 @@
   "Initializes and starts the whole system."
   [default-configuration]
   (let [configuration (config/load-configuration
-                        (system/default-http-namespaces-and :db :essentials :oauth2)
+                        (system/default-http-namespaces-and :db :essentials)
                         [sql/default-db-configuration
                          api/default-http-configuration
                          default-configuration])

--- a/src/org/zalando/stups/essentials/external/kio.clj
+++ b/src/org/zalando/stups/essentials/external/kio.clj
@@ -3,18 +3,18 @@
             [org.zalando.stups.friboo.log :as log]
             [org.zalando.stups.friboo.system.oauth2 :as oauth]))
 
-(defn- make-auth-header
+(defn- make-options
   [tokens]
-  {:authorization (str "Bearer " (oauth/access-token :kio tokens))})
+  {:headers {:authorization (str "Bearer " (oauth/access-token :kio tokens))}
+   :accept :json
+   :as :json})
 
 (defn get-app
   "Fetches application with this id from kio, returns nil if it does not exist"
   [kio-url id tokens]
-  {:pre (not (clojure.string/blank? id))}
-  (let [header (make-auth-header tokens)]
+  {:pre [(not (clojure.string/blank? id))]}
+  (let [options (make-options tokens)]
     (try
-      (-> (http/get (str kio-url "/" id) header)
-          :body)
-      (catch Exception ex
-        (log/warn "Could not find application %s in Kio. %s" id ex)
+      (:body (http/get (str kio-url "/apps/" id) options))
+      (catch Exception _
         nil))))

--- a/src/org/zalando/stups/essentials/external/kio.clj
+++ b/src/org/zalando/stups/essentials/external/kio.clj
@@ -1,0 +1,20 @@
+(ns org.zalando.stups.essentials.external.kio
+  (:require [clj-http.client :as http]
+            [org.zalando.stups.friboo.log :as log]
+            [org.zalando.stups.friboo.system.oauth2 :as oauth]))
+
+(defn- make-auth-header
+  [tokens]
+  {:authorization (str "Bearer " (oauth/access-token :kio tokens))})
+
+(defn get-app
+  "Fetches application with this id from kio, returns nil if it does not exist"
+  [kio-url id tokens]
+  {:pre (not (clojure.string/blank? id))}
+  (let [header (make-auth-header tokens)]
+    (try
+      (-> (http/get (str kio-url "/" id) header)
+          :body)
+      (catch Exception ex
+        (log/warn "Could not find application %s in Kio. %s" id ex)
+        nil))))


### PR DESCRIPTION
- If part before first dot in resource type looks like an app, verify that it belongs to the user's team
- If such app doesn't exist, fall back to special uids
- Make read access possible without teams

Fixes #8 
