### PR TITLE
Fix db query with optional API parameters

### DIFF
--- a/src/org/zalando/stups/essentials/api.clj
+++ b/src/org/zalando/stups/essentials/api.clj
@@ -199,8 +199,12 @@
           (throw-error
             400
             "A resource-owner-scope requires its resource type to have at least one resource owner"
-            {:resource_type_id resource_type_id :scope_id scope_id}))
-        (let [defaults {:criticality_level 2}
+            {:resource_type_id resource_type_id
+             :scope_id scope_id}))
+        (let [defaults {:criticality_level 2
+                        :description       nil
+                        :user_information  nil
+                        :summary           nil}
               scope-keys (select-keys scope [:summary
                                              :description
                                              :user_information


### PR DESCRIPTION
Behavior: PUT request to a scope failed because it did not contain `user_information`, which is an optional API field. This was because it was not added in the handling function and the DB query failed due to this missing parameter.

Fixes #14 by adding optional fields as `nil` to the defaults.
