### PR TITLE
Enable users to disable auto DB migration through an env variable

### DIFF
--- a/test/org/zalando/stups/essentials/core_test.clj
+++ b/test/org/zalando/stups/essentials/core_test.clj
@@ -26,4 +26,10 @@
         (finally
           (component/stop system)))))
 
-  )
+  (facts "about load-config"
+         (fact "not setting DB_AUTO_MIGRATION gives us the default"
+               (get-in (load-config {}) [:db :auto-migration?]) => (:db-auto-migration? default-db-config))
+         (fact "setting DB_AUTO_MIGRATION to 1 leaves automatic migration enabled"
+               (get-in (load-config {:db-auto-migration "1"}) [:db :auto-migration?]) => true)
+         (fact "setting DB_AUTO_MIGRATION to 0 disables automatic migration"
+               (get-in (load-config {:db-auto-migration "0"}) [:db :auto-migration?]) => false)))


### PR DESCRIPTION
This is required for migrating essentials to the cluster; Flyway can't handle read-only databases, and we can't write before promoting the replica.